### PR TITLE
Implement Firestore CRUD hooks and dashboard forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,10 @@ This project uses React, Vite and Tailwind.
 2. Install dependencies with `npm install`.
 3. Run `npm run dev` to start the development server.
 
-At this stage you can sign in with Google and access an empty dashboard.
+At this stage you can sign in with Google and manage your data.
+
+## Features
+
+- Accounts and transactions are stored in Firestore under each user
+- Offline persistence is enabled automatically
+- Press **N** anywhere to quickly add a transaction

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,5 +1,6 @@
 import { initializeApp } from 'firebase/app'
 import { getAuth } from 'firebase/auth'
+import { getFirestore, enableIndexedDbPersistence } from 'firebase/firestore'
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -12,4 +13,9 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig)
 export const auth = getAuth(app)
+export const db = getFirestore(app)
+
+enableIndexedDbPersistence(db).catch(() => {
+  console.warn('Offline persistence could not be enabled')
+})
 

--- a/src/hooks/useAccounts.tsx
+++ b/src/hooks/useAccounts.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react'
+import {
+  collection,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  doc,
+  onSnapshot,
+} from 'firebase/firestore'
+import { useAuth } from '../AuthProvider'
+import { db } from '../firebase'
+import { Account } from '../types'
+
+export const useAccounts = () => {
+  const { user } = useAuth()
+  const [accounts, setAccounts] = useState<Account[]>([])
+
+  useEffect(() => {
+    if (!user) return
+    const col = collection(db, 'users', user.uid, 'accounts')
+    return onSnapshot(col, (snap) => {
+      setAccounts(
+        snap.docs.map((d) => ({ id: d.id, ...(d.data() as Account) }))
+      )
+    })
+  }, [user])
+
+  const addAccount = async (account: Account) => {
+    if (!user) return
+    const col = collection(db, 'users', user.uid, 'accounts')
+    await addDoc(col, account)
+  }
+
+  const updateAccount = async (id: string, data: Partial<Account>) => {
+    if (!user) return
+    await updateDoc(doc(db, 'users', user.uid, 'accounts', id), data)
+  }
+
+  const deleteAccount = async (id: string) => {
+    if (!user) return
+    await deleteDoc(doc(db, 'users', user.uid, 'accounts', id))
+  }
+
+  return { accounts, addAccount, updateAccount, deleteAccount }
+}

--- a/src/hooks/useGoals.tsx
+++ b/src/hooks/useGoals.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+import {
+  collection,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  doc,
+  onSnapshot,
+} from 'firebase/firestore'
+import { useAuth } from '../AuthProvider'
+import { db } from '../firebase'
+import { Goal } from '../types'
+
+export const useGoals = () => {
+  const { user } = useAuth()
+  const [goals, setGoals] = useState<Goal[]>([])
+
+  useEffect(() => {
+    if (!user) return
+    const col = collection(db, 'users', user.uid, 'goals')
+    return onSnapshot(col, (snap) => {
+      setGoals(snap.docs.map((d) => ({ id: d.id, ...(d.data() as Goal) })))
+    })
+  }, [user])
+
+  const addGoal = async (goal: Goal) => {
+    if (!user) return
+    const col = collection(db, 'users', user.uid, 'goals')
+    await addDoc(col, goal)
+  }
+
+  const updateGoal = async (id: string, data: Partial<Goal>) => {
+    if (!user) return
+    await updateDoc(doc(db, 'users', user.uid, 'goals', id), data)
+  }
+
+  const deleteGoal = async (id: string) => {
+    if (!user) return
+    await deleteDoc(doc(db, 'users', user.uid, 'goals', id))
+  }
+
+  return { goals, addGoal, updateGoal, deleteGoal }
+}

--- a/src/hooks/useTransactions.tsx
+++ b/src/hooks/useTransactions.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react'
+import {
+  collection,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  doc,
+  onSnapshot,
+} from 'firebase/firestore'
+import { useAuth } from '../AuthProvider'
+import { db } from '../firebase'
+import { Transaction } from '../types'
+
+export const useTransactions = () => {
+  const { user } = useAuth()
+  const [transactions, setTransactions] = useState<Transaction[]>([])
+
+  useEffect(() => {
+    if (!user) return
+    const col = collection(db, 'users', user.uid, 'tx')
+    return onSnapshot(col, (snap) => {
+      setTransactions(
+        snap.docs.map((d) => ({ id: d.id, ...(d.data() as Transaction) }))
+      )
+    })
+  }, [user])
+
+  const addTransaction = async (tx: Transaction) => {
+    if (!user) return
+    const col = collection(db, 'users', user.uid, 'tx')
+    await addDoc(col, tx)
+  }
+
+  const updateTransaction = async (id: string, data: Partial<Transaction>) => {
+    if (!user) return
+    await updateDoc(doc(db, 'users', user.uid, 'tx', id), data)
+  }
+
+  const deleteTransaction = async (id: string) => {
+    if (!user) return
+    await deleteDoc(doc(db, 'users', user.uid, 'tx', id))
+  }
+
+  return { transactions, addTransaction, updateTransaction, deleteTransaction }
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,7 +1,150 @@
+import { useState, useEffect } from 'react'
+import { useAccounts } from '../hooks/useAccounts'
+import { useTransactions } from '../hooks/useTransactions'
+import { AccountType, TransactionType } from '../types'
+
 export default function Dashboard() {
+  const { accounts, addAccount } = useAccounts()
+  const { transactions, addTransaction } = useTransactions()
+
+  const [accName, setAccName] = useState('')
+  const [accType, setAccType] = useState<AccountType>('cash')
+  const [accCurrency, setAccCurrency] = useState('ARS')
+
+  const [showTx, setShowTx] = useState(false)
+  const [txAmount, setTxAmount] = useState('')
+  const [txType, setTxType] = useState<TransactionType>('income')
+  const [txAccount, setTxAccount] = useState('')
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === 'n') {
+        setShowTx(true)
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [])
+
+  const submitAccount = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!accName) return
+    await addAccount({ name: accName, type: accType, currency: accCurrency })
+    setAccName('')
+  }
+
+  const submitTx = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const amount = parseFloat(txAmount)
+    if (!txAccount || amount <= 0) return
+    await addTransaction({
+      type: txType,
+      amount,
+      date: new Date().toISOString(),
+      fromAccount: txAccount,
+    })
+    setTxAmount('')
+    setShowTx(false)
+  }
+
   return (
     <div>
-      <h1 className="text-2xl font-bold">Dashboard</h1>
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+
+      <form onSubmit={submitAccount} className="space-x-2 mb-6">
+        <input
+          value={accName}
+          onChange={(e) => setAccName(e.target.value)}
+          placeholder="Account name"
+          className="border px-2 py-1"
+        />
+        <select
+          value={accType}
+          onChange={(e) => setAccType(e.target.value as AccountType)}
+          className="border px-2 py-1"
+        >
+          <option value="cash">Cash</option>
+          <option value="mercadopago_ars">Mercadopago ARS</option>
+          <option value="mp_usd">MP USD</option>
+          <option value="mp_reserva">MP Reserva</option>
+          <option value="binance">Binance</option>
+          <option value="balance_acc">Balance Account</option>
+        </select>
+        <select
+          value={accCurrency}
+          onChange={(e) => setAccCurrency(e.target.value)}
+          className="border px-2 py-1"
+        >
+          <option value="ARS">ARS</option>
+          <option value="USD">USD</option>
+          <option value="BTC">BTC</option>
+        </select>
+        <button type="submit" className="bg-blue-500 text-white px-2 py-1 rounded">
+          Add Account
+        </button>
+      </form>
+
+      <ul className="mb-8 space-y-1">
+        {accounts.map((a) => (
+          <li key={a.id} className="border p-2">
+            {a.name} - {a.currency}
+          </li>
+        ))}
+      </ul>
+
+      {showTx && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+          <form onSubmit={submitTx} className="bg-white p-4 space-y-2 rounded">
+            <select
+              value={txAccount}
+              onChange={(e) => setTxAccount(e.target.value)}
+              className="border px-2 py-1 w-full"
+            >
+              <option value="" disabled>
+                Select account
+              </option>
+              {accounts.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.name}
+                </option>
+              ))}
+            </select>
+            <input
+              type="number"
+              value={txAmount}
+              onChange={(e) => setTxAmount(e.target.value)}
+              className="border px-2 py-1 w-full"
+              placeholder="Amount"
+              step="0.01"
+            />
+            <select
+              value={txType}
+              onChange={(e) => setTxType(e.target.value as TransactionType)}
+              className="border px-2 py-1 w-full"
+            >
+              <option value="income">Income</option>
+              <option value="expense">Expense</option>
+            </select>
+            <div className="flex justify-end space-x-2">
+              <button type="button" onClick={() => setShowTx(false)} className="px-2 py-1 border">
+                Cancel
+              </button>
+              <button type="submit" className="px-2 py-1 bg-blue-500 text-white">
+                Add
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      <h2 className="font-semibold mb-2">Transactions</h2>
+      <ul className="space-y-1">
+        {transactions.map((tx) => (
+          <li key={tx.id} className="border p-2">
+            {tx.type} - {tx.amount}
+          </li>
+        ))}
+      </ul>
     </div>
   )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,47 @@
+export type AccountType =
+  | 'cash'
+  | 'mercadopago_ars'
+  | 'mp_usd'
+  | 'mp_reserva'
+  | 'binance'
+  | 'balance_acc'
+
+export interface Account {
+  id?: string
+  name: string
+  type: AccountType
+  currency: string
+}
+
+export interface Category {
+  id?: string
+  name: string
+  color: string
+}
+
+export type TransactionType =
+  | 'income'
+  | 'expense'
+  | 'transfer'
+  | 'asset_buy'
+  | 'asset_sell'
+  | 'yield'
+  | 'fee'
+  | 'tax'
+
+export interface Transaction {
+  id?: string
+  type: TransactionType
+  amount: number
+  date: string
+  fromAccount?: string
+  toAccount?: string
+  categoryId?: string
+}
+
+export interface Goal {
+  id?: string
+  targetType: 'save_pct' | 'invest_pct'
+  pct: number
+  period: 'mensual'
+}


### PR DESCRIPTION
## Summary
- enable Firestore with offline persistence
- add TypeScript models for accounts, transactions and goals
- create hooks for accounts, transactions and goals CRUD
- add quick account and transaction forms in Dashboard
- document new features

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c8f9a02d8832a9b449cc226fee402