### PR TITLE
Implement basic dashboard visualizations

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,11 +1,15 @@
 import { useState, useEffect } from 'react'
 import { useAccounts } from '../hooks/useAccounts'
 import { useTransactions } from '../hooks/useTransactions'
+import { useGoals } from '../hooks/useGoals'
 import { AccountType, TransactionType } from '../types'
+import { Bar, Pie } from 'react-chartjs-2'
+import 'chart.js/auto'
 
 export default function Dashboard() {
   const { accounts, addAccount } = useAccounts()
   const { transactions, addTransaction } = useTransactions()
+  const { goals } = useGoals()
 
   const [accName, setAccName] = useState('')
   const [accType, setAccType] = useState<AccountType>('cash')
@@ -15,6 +19,11 @@ export default function Dashboard() {
   const [txAmount, setTxAmount] = useState('')
   const [txType, setTxType] = useState<TransactionType>('income')
   const [txAccount, setTxAccount] = useState('')
+
+  const [range, setRange] = useState<'month' | 'quarter' | 'year'>('month')
+  const [showUsd, setShowUsd] = useState(false)
+
+  const USD_RATE = 1000 // ARS per USD - placeholder value
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -46,6 +55,85 @@ export default function Dashboard() {
     setTxAmount('')
     setShowTx(false)
   }
+
+  const now = new Date()
+  const rangeStart = (() => {
+    if (range === 'month') return new Date(now.getFullYear(), now.getMonth(), 1)
+    if (range === 'quarter')
+      return new Date(now.getFullYear(), now.getMonth() - 2, 1)
+    return new Date(now.getFullYear(), 0, 1)
+  })()
+
+  const filteredTx = transactions.filter(
+    (t) => new Date(t.date) >= rangeStart
+  )
+
+  const balances: Record<string, number> = {}
+  filteredTx.forEach((t) => {
+    const acc = accounts.find((a) => a.id === t.fromAccount)
+    if (!acc) return
+    const sign =
+      t.type === 'expense' ||
+      t.type === 'asset_buy' ||
+      t.type === 'fee' ||
+      t.type === 'tax'
+        ? -1
+        : 1
+    balances[acc.currency] = (balances[acc.currency] || 0) + sign * t.amount
+  })
+
+  const balanceEntries = Object.entries(balances)
+  const showBalances = balanceEntries.map(([cur, val]) => {
+    if (showUsd && cur === 'ARS') return ['USD', val / USD_RATE]
+    return [cur, val]
+  })
+
+  const months = Array.from({ length: 12 }).map((_, i) => {
+    const d = new Date(now.getFullYear(), now.getMonth() - (11 - i), 1)
+    return `${d.getMonth() + 1}/${String(d.getFullYear()).slice(2)}`
+  })
+  const incomeSeries = Array(12).fill(0)
+  const expenseSeries = Array(12).fill(0)
+  transactions.forEach((t) => {
+    const d = new Date(t.date)
+    const idx =
+      11 - (now.getFullYear() * 12 + now.getMonth() - (d.getFullYear() * 12 + d.getMonth()))
+    if (idx < 0 || idx > 11) return
+    if (t.type === 'income') incomeSeries[idx] += t.amount
+    if (t.type === 'expense') expenseSeries[idx] += t.amount
+  })
+
+  const thisMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+  const catTotals: Record<string, number> = {}
+  transactions
+    .filter((t) => t.type === 'expense' && new Date(t.date) >= thisMonth)
+    .forEach((t) => {
+      const cat = t.categoryId || 'Uncategorized'
+      catTotals[cat] = (catTotals[cat] || 0) + t.amount
+    })
+
+  const goalProgress = goals.map((g) => {
+    const start = new Date(now.getFullYear(), now.getMonth(), 1)
+    const periodTx = transactions.filter((t) => new Date(t.date) >= start)
+    const income = periodTx
+      .filter((t) => t.type === 'income')
+      .reduce((sum, t) => sum + t.amount, 0)
+    let pct = 0
+    if (g.targetType === 'save_pct') {
+      const expense = periodTx
+        .filter((t) => t.type === 'expense')
+        .reduce((sum, t) => sum + t.amount, 0)
+      if (income > 0) pct = ((income - expense) / income) * 100
+    }
+    if (g.targetType === 'invest_pct') {
+      const invest = periodTx
+        .filter((t) => t.type === 'asset_buy')
+        .reduce((sum, t) => sum + t.amount, 0)
+      if (income > 0) pct = (invest / income) * 100
+    }
+    const progress = Math.max(0, Math.min(100, (pct / g.pct) * 100))
+    return { id: g.id, pct: progress, goal: g.pct }
+  })
 
   return (
     <div>
@@ -145,6 +233,91 @@ export default function Dashboard() {
           </li>
         ))}
       </ul>
+
+      <div className="mt-8 space-y-6">
+        <div>
+          <div className="flex items-center space-x-2 mb-2">
+            <select
+              value={range}
+              onChange={(e) => setRange(e.target.value as typeof range)}
+              className="border px-2 py-1"
+            >
+              <option value="month">Mes</option>
+              <option value="quarter">Trimestre</option>
+              <option value="year">Año</option>
+            </select>
+            <label className="flex items-center space-x-1">
+              <input
+                type="checkbox"
+                checked={showUsd}
+                onChange={(e) => setShowUsd(e.target.checked)}
+              />
+              <span>Mostrar en USD</span>
+            </label>
+          </div>
+          <ul className="space-y-1">
+            {showBalances.map(([cur, val]) => (
+              <li key={cur} className="font-semibold">
+                {cur}: {val.toFixed(2)}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div>
+          <h3 className="font-semibold mb-2">Ingresos vs Gastos (12m)</h3>
+          <Bar
+            data={{
+              labels: months,
+              datasets: [
+                { label: 'Ingresos', data: incomeSeries, backgroundColor: '#4ade80' },
+                { label: 'Gastos', data: expenseSeries, backgroundColor: '#f87171' },
+              ],
+            }}
+          />
+        </div>
+
+        <div>
+          <h3 className="font-semibold mb-2">Gasto por categoría (mes)</h3>
+          <Pie
+            data={{
+              labels: Object.keys(catTotals),
+              datasets: [
+                {
+                  data: Object.values(catTotals),
+                  backgroundColor: [
+                    '#93c5fd',
+                    '#fca5a5',
+                    '#fdba74',
+                    '#fde047',
+                    '#86efac',
+                    '#a5b4fc',
+                  ],
+                },
+              ],
+            }}
+          />
+        </div>
+
+        {goalProgress.length > 0 && (
+          <div>
+            <h3 className="font-semibold mb-2">Progreso de metas</h3>
+            <ul className="space-y-2">
+              {goalProgress.map((g) => (
+                <li key={g.id} className="space-y-1">
+                  <div className="h-2 bg-gray-200 rounded">
+                    <div
+                      className="h-2 bg-blue-500 rounded"
+                      style={{ width: `${g.pct}%` }}
+                    />
+                  </div>
+                  <span>{g.pct.toFixed(1)}% de objetivo {g.goal}%</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add chart.js and goals hook to dashboard
- compute balances filtered by range
- display balance with ARS/USD toggle
- show income vs expense bars, category pie chart and goal progress bars

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c908a83b4832a9c7792a00a107190