### PR TITLE
Implement basic rate automation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "fetchUsdArs": "node scripts/fetchUsdArs.js",
+    "fetchMpYield": "node scripts/fetchMpYield.js",
+    "applyMpYield": "node scripts/applyMpYield.js"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -15,7 +18,8 @@
     "chart.js": "^4.2.1",
     "zustand": "^4.4.0",
     "firebase": "^9.23.0",
-    "react-router-dom": "^6.14.1"
+    "react-router-dom": "^6.14.1",
+    "firebase-admin": "^11.10.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/scripts/applyMpYield.js
+++ b/scripts/applyMpYield.js
@@ -1,0 +1,66 @@
+import { initializeApp, cert } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT;
+if (!serviceAccount) {
+  console.error('Missing FIREBASE_SERVICE_ACCOUNT env var');
+  process.exit(1);
+}
+initializeApp({ credential: cert(JSON.parse(serviceAccount)) });
+
+const db = getFirestore();
+
+function dateId(d) {
+  return d.toISOString().slice(0, 10).replace(/-/g, '');
+}
+
+async function calcBalance(col, accountId, upto) {
+  const snap = await col.where('fromAccount', '==', accountId).where('date', '<=', upto.toISOString()).get();
+  let bal = 0;
+  snap.forEach((doc) => {
+    const t = doc.data();
+    const sign =
+      t.type === 'expense' || t.type === 'asset_buy' || t.type === 'fee' || t.type === 'tax'
+        ? -1
+        : 1;
+    bal += sign * t.amount;
+  });
+  return bal;
+}
+
+async function main() {
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+
+  const yieldDoc = await db.doc(`rates/mpYield/${dateId(yesterday)}`).get();
+  const tna = yieldDoc.exists ? yieldDoc.data().tna : 0;
+
+  const users = await db.collection('users').listDocuments();
+  for (const user of users) {
+    const accSnap = await user.collection('accounts').where('type', '==', 'mp_reserva').get();
+    for (const acc of accSnap.docs) {
+      const txCol = user.collection('tx');
+      const existsSnap = await txCol
+        .where('type', '==', 'yield')
+        .where('date', '==', yesterday.toISOString())
+        .where('fromAccount', '==', acc.id)
+        .get();
+      if (!existsSnap.empty) continue;
+      const balance = await calcBalance(txCol, acc.id, yesterday);
+      const amount = balance * (tna / 365 / 100);
+      await txCol.add({
+        type: 'yield',
+        amount,
+        date: yesterday.toISOString(),
+        fromAccount: acc.id,
+      });
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/fetchMpYield.js
+++ b/scripts/fetchMpYield.js
@@ -1,0 +1,28 @@
+import { initializeApp, cert } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT;
+if (!serviceAccount) {
+  console.error('Missing FIREBASE_SERVICE_ACCOUNT env var');
+  process.exit(1);
+}
+initializeApp({ credential: cert(JSON.parse(serviceAccount)) });
+
+const db = getFirestore();
+
+async function main() {
+  const endpoint = process.env.MP_YIELD_ENDPOINT;
+  if (!endpoint) throw new Error('Missing MP_YIELD_ENDPOINT env var');
+  const resp = await fetch(endpoint);
+  if (!resp.ok) throw new Error(`API error ${resp.status}`);
+  const data = await resp.json();
+  const tna = data.tna || data.rate;
+  const now = new Date();
+  const id = now.toISOString().slice(0, 10).replace(/-/g, '');
+  await db.doc(`rates/mpYield/${id}`).set({ tna, fetchedAt: now.toISOString() });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/fetchUsdArs.js
+++ b/scripts/fetchUsdArs.js
@@ -1,0 +1,26 @@
+import { initializeApp, cert } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT;
+if (!serviceAccount) {
+  console.error('Missing FIREBASE_SERVICE_ACCOUNT env var');
+  process.exit(1);
+}
+initializeApp({ credential: cert(JSON.parse(serviceAccount)) });
+
+const db = getFirestore();
+
+async function main() {
+  const resp = await fetch('https://dolarapi.com/v1/dolares/oficial');
+  if (!resp.ok) throw new Error(`API error ${resp.status}`);
+  const data = await resp.json();
+  const rate = data.venta || data.sell || data.rate;
+  const now = new Date();
+  const id = now.toISOString().slice(0, 10).replace(/-/g, '');
+  await db.doc(`rates/dailyUSD/${id}`).set({ rate, fetchedAt: now.toISOString() });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/hooks/useRates.tsx
+++ b/src/hooks/useRates.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+import { collection, query, orderBy, limit, onSnapshot } from 'firebase/firestore'
+import { db } from '../firebase'
+
+export const useRates = () => {
+  const [usdRate, setUsdRate] = useState<number>()
+  const [mpTna, setMpTna] = useState<number>()
+
+  useEffect(() => {
+    const q = query(collection(db, 'rates', 'dailyUSD'), orderBy('__name__', 'desc'), limit(1))
+    return onSnapshot(q, (snap) => {
+      if (!snap.empty) {
+        const d = snap.docs[0].data() as any
+        setUsdRate(d.rate)
+      }
+    })
+  }, [])
+
+  useEffect(() => {
+    const q = query(collection(db, 'rates', 'mpYield'), orderBy('__name__', 'desc'), limit(1))
+    return onSnapshot(q, (snap) => {
+      if (!snap.empty) {
+        const d = snap.docs[0].data() as any
+        setMpTna(d.tna)
+      }
+    })
+  }, [])
+
+  return { usdRate, mpTna }
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useAccounts } from '../hooks/useAccounts'
 import { useTransactions } from '../hooks/useTransactions'
 import { useGoals } from '../hooks/useGoals'
+import { useRates } from '../hooks/useRates'
 import { AccountType, TransactionType } from '../types'
 import { Bar, Pie } from 'react-chartjs-2'
 import 'chart.js/auto'
@@ -22,8 +23,7 @@ export default function Dashboard() {
 
   const [range, setRange] = useState<'month' | 'quarter' | 'year'>('month')
   const [showUsd, setShowUsd] = useState(false)
-
-  const USD_RATE = 1000 // ARS per USD - placeholder value
+  const { usdRate } = useRates()
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -84,7 +84,7 @@ export default function Dashboard() {
 
   const balanceEntries = Object.entries(balances)
   const showBalances = balanceEntries.map(([cur, val]) => {
-    if (showUsd && cur === 'ARS') return ['USD', val / USD_RATE]
+    if (showUsd && cur === 'ARS' && usdRate) return ['USD', val / usdRate]
     return [cur, val]
   })
 


### PR DESCRIPTION
## Summary
- add firebase-admin for scripts
- implement scripts to fetch USD rate and MercadoPago yield rate
- script for applying yield to MP reserva accounts
- expose rates via new `useRates` hook
- display ARS balances in USD using latest quote

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c919811dc832ab613ce8a578cdb73