### PR TITLE
Add import/export and drive backup

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "zustand": "^4.4.0",
     "firebase": "^9.23.0",
     "react-router-dom": "^6.14.1",
-    "firebase-admin": "^11.10.1"
+    "firebase-admin": "^11.10.1",
+    "papaparse": "^5.4.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -1,0 +1,75 @@
+import { collection, getDocs, doc, getDoc, addDoc } from 'firebase/firestore'
+import { db } from './firebase'
+import { Account, Transaction, Goal } from './types'
+import Papa from 'papaparse'
+
+export interface BackupData {
+  accounts: Account[]
+  transactions: Transaction[]
+  goals: Goal[]
+}
+
+export async function fetchBackupData(uid: string): Promise<BackupData> {
+  const accountsSnap = await getDocs(collection(db, 'users', uid, 'accounts'))
+  const txSnap = await getDocs(collection(db, 'users', uid, 'tx'))
+  const goalsSnap = await getDocs(collection(db, 'users', uid, 'goals'))
+  return {
+    accounts: accountsSnap.docs.map((d) => ({ id: d.id, ...(d.data() as Account) })),
+    transactions: txSnap.docs.map((d) => ({ id: d.id, ...(d.data() as Transaction) })),
+    goals: goalsSnap.docs.map((d) => ({ id: d.id, ...(d.data() as Goal) })),
+  }
+}
+
+export function toJSONBlob(data: BackupData): Blob {
+  return new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+}
+
+export function toCsvBlob(data: BackupData): Blob {
+  const rows: any[] = []
+  data.accounts.forEach((a) => rows.push({ collection: 'accounts', ...a }))
+  data.transactions.forEach((t) => rows.push({ collection: 'tx', ...t }))
+  data.goals.forEach((g) => rows.push({ collection: 'goals', ...g }))
+  const csv = Papa.unparse(rows)
+  return new Blob([csv], { type: 'text/csv' })
+}
+
+export async function importCsv(uid: string, file: File) {
+  const text = await file.text()
+  const parsed = Papa.parse(text, { header: true })
+  if (!parsed.data || !Array.isArray(parsed.data)) return
+  for (const row of parsed.data as any[]) {
+    if (!row.collection) continue
+    const { collection: col, id, ...rest } = row as any
+    await addDoc(collection(db, 'users', uid, col), rest)
+  }
+}
+
+export async function uploadBackup(uid: string, data: BackupData) {
+  const tokenDoc = await getDoc(doc(db, 'users', uid, 'driveToken'))
+  if (!tokenDoc.exists()) return
+  const token = tokenDoc.data().access_token as string
+  const metadata = { name: `fintracker_backup_${Date.now()}.json` }
+  const boundary = 'BOUNDARY'
+  const body =
+    `--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n` +
+    JSON.stringify(metadata) +
+    `\r\n--${boundary}\r\nContent-Type: application/json\r\n\r\n` +
+    JSON.stringify(data) +
+    `\r\n--${boundary}--`
+  await fetch(
+    'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart',
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': `multipart/related; boundary=${boundary}`,
+      },
+      body,
+    }
+  )
+}
+
+export async function triggerBackup(uid: string) {
+  const data = await fetchBackupData(uid)
+  await uploadBackup(uid, data)
+}

--- a/src/hooks/useAccounts.tsx
+++ b/src/hooks/useAccounts.tsx
@@ -10,6 +10,7 @@ import {
 import { useAuth } from '../AuthProvider'
 import { db } from '../firebase'
 import { Account } from '../types'
+import { triggerBackup } from '../backup'
 
 export const useAccounts = () => {
   const { user } = useAuth()
@@ -29,16 +30,19 @@ export const useAccounts = () => {
     if (!user) return
     const col = collection(db, 'users', user.uid, 'accounts')
     await addDoc(col, account)
+    await triggerBackup(user.uid)
   }
 
   const updateAccount = async (id: string, data: Partial<Account>) => {
     if (!user) return
     await updateDoc(doc(db, 'users', user.uid, 'accounts', id), data)
+    await triggerBackup(user.uid)
   }
 
   const deleteAccount = async (id: string) => {
     if (!user) return
     await deleteDoc(doc(db, 'users', user.uid, 'accounts', id))
+    await triggerBackup(user.uid)
   }
 
   return { accounts, addAccount, updateAccount, deleteAccount }

--- a/src/hooks/useGoals.tsx
+++ b/src/hooks/useGoals.tsx
@@ -10,6 +10,7 @@ import {
 import { useAuth } from '../AuthProvider'
 import { db } from '../firebase'
 import { Goal } from '../types'
+import { triggerBackup } from '../backup'
 
 export const useGoals = () => {
   const { user } = useAuth()
@@ -27,16 +28,19 @@ export const useGoals = () => {
     if (!user) return
     const col = collection(db, 'users', user.uid, 'goals')
     await addDoc(col, goal)
+    await triggerBackup(user.uid)
   }
 
   const updateGoal = async (id: string, data: Partial<Goal>) => {
     if (!user) return
     await updateDoc(doc(db, 'users', user.uid, 'goals', id), data)
+    await triggerBackup(user.uid)
   }
 
   const deleteGoal = async (id: string) => {
     if (!user) return
     await deleteDoc(doc(db, 'users', user.uid, 'goals', id))
+    await triggerBackup(user.uid)
   }
 
   return { goals, addGoal, updateGoal, deleteGoal }

--- a/src/hooks/useTransactions.tsx
+++ b/src/hooks/useTransactions.tsx
@@ -10,6 +10,7 @@ import {
 import { useAuth } from '../AuthProvider'
 import { db } from '../firebase'
 import { Transaction } from '../types'
+import { triggerBackup } from '../backup'
 
 export const useTransactions = () => {
   const { user } = useAuth()
@@ -29,16 +30,19 @@ export const useTransactions = () => {
     if (!user) return
     const col = collection(db, 'users', user.uid, 'tx')
     await addDoc(col, tx)
+    await triggerBackup(user.uid)
   }
 
   const updateTransaction = async (id: string, data: Partial<Transaction>) => {
     if (!user) return
     await updateDoc(doc(db, 'users', user.uid, 'tx', id), data)
+    await triggerBackup(user.uid)
   }
 
   const deleteTransaction = async (id: string) => {
     if (!user) return
     await deleteDoc(doc(db, 'users', user.uid, 'tx', id))
+    await triggerBackup(user.uid)
   }
 
   return { transactions, addTransaction, updateTransaction, deleteTransaction }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,7 +1,60 @@
+import { useState } from 'react'
+import { useAuth } from '../AuthProvider'
+import { fetchBackupData, toJSONBlob, toCsvBlob, importCsv } from '../backup'
+
 export default function Settings() {
+  const { user } = useAuth()
+  const [file, setFile] = useState<File | null>(null)
+
+  const downloadBackup = async () => {
+    if (!user) return
+    const data = await fetchBackupData(user.uid)
+    const blob = toJSONBlob(data)
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'fintracker_backup.json'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const downloadCsv = async () => {
+    if (!user) return
+    const data = await fetchBackupData(user.uid)
+    const blob = toCsvBlob(data)
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'fintracker_backup.csv'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const importFile = async () => {
+    if (!user || !file) return
+    await importCsv(user.uid, file)
+    setFile(null)
+  }
+
   return (
     <div>
-      <h1 className="text-2xl font-bold">Settings</h1>
+      <h1 className="text-2xl font-bold mb-4">Settings</h1>
+      <button onClick={downloadBackup} className="border px-2 py-1 mr-2">
+        Descargar backup
+      </button>
+      <button onClick={downloadCsv} className="border px-2 py-1 mr-2">
+        Exportar CSV
+      </button>
+      <div className="mt-4">
+        <input
+          type="file"
+          accept=".csv"
+          onChange={(e) => setFile(e.target.files?.[0] || null)}
+        />
+        <button onClick={importFile} className="ml-2 border px-2 py-1">
+          Importar CSV
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add `papaparse` dependency
- create backup utilities for export, import and Google Drive upload
- trigger Drive backup on account, transaction and goal mutations
- enable data export/import controls in Settings page

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c95d695e0832a96f8e911af077d1a