### PR TITLE
Add Phase 6 planning document

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,15 @@ At this stage you can sign in with Google and manage your data.
 - Accounts and transactions are stored in Firestore under each user
 - Offline persistence is enabled automatically
 - Press **N** anywhere to quickly add a transaction
+
+## Deploying your fork
+
+After running `npm run build`, you can publish the contents of the `dist` folder to GitHub Pages using the `gh-pages` package:
+
+```bash
+npx gh-pages -d dist
+```
+
+## Further documentation
+
+Additional project planning notes are available in [`docs/phase6-plan.md`](docs/phase6-plan.md).

--- a/docs/phase6-plan.md
+++ b/docs/phase6-plan.md
@@ -1,0 +1,18 @@
+# Phase 6 – Polishing and QA
+
+This document outlines the tasks planned for the polishing and quality assurance phase of the project. The estimated duration is one week, running continuously.
+
+## Tests
+- **Unit tests** covering goal calculations and currency conversion.
+- **End-to-end tests** using Playwright for the flow: login → add transaction → view dashboard.
+- **Accessibility checks** focusing on ARIA roles and keyboard navigation.
+- Run **Lighthouse** to achieve at least 90 in Performance, Accessibility and Best Practices.
+
+## Documentation
+- Update the `README` with screenshots, environment variable guide and instructions to deploy your own fork.
+- Maintain a project wiki documenting the Firestore structure and field naming conventions.
+
+## Versioning
+Follow semantic versioning. Example tags:
+- `v0.1.0` – Minimum viable product.
+- `v0.2.0` – Automation features.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "fetchUsdArs": "node scripts/fetchUsdArs.js",
     "fetchMpYield": "node scripts/fetchMpYield.js",
-    "applyMpYield": "node scripts/applyMpYield.js"
+    "applyMpYield": "node scripts/applyMpYield.js",
+    "deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- add project plan for Phase 6 to `docs/phase6-plan.md`
- describe how to deploy a fork in `README`
- provide `deploy` npm script for gh-pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_686c96d34e50832a9ebdb0294530c942