### PR TITLE
Add Phase 7 planning doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ npx gh-pages -d dist
 
 ## Further documentation
 
-Additional project planning notes are available in [`docs/phase6-plan.md`](docs/phase6-plan.md).
+Additional project planning notes are available in [`docs/phase6-plan.md`](docs/phase6-plan.md) and [`docs/phase7-plan.md`](docs/phase7-plan.md).

--- a/docs/phase7-plan.md
+++ b/docs/phase7-plan.md
@@ -1,0 +1,10 @@
+# Phase 7 – Optional Future Work
+
+This document lists potential future enhancements that can be explored when time allows.
+
+- Integrate the real Mercado Pago API (requires user OAuth).
+- Hook Binance balances using `GET /api/v3/account`.
+- Automatically record dividends via BYMA or Polygon.
+- Provide a PWA experience with local push notifications for mobile installation.
+- Android widget (WebView) showing quick balance.
+- Analyze portfolio performance against IPC inflation.


### PR DESCRIPTION
## Summary
- outline optional future work in a new Phase 7 planning doc
- mention the new doc in the README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c9769587c832aa8247addd9cf7287