### PR TITLE
Fix importCsv bug

### DIFF
--- a/src/backup.ts
+++ b/src/backup.ts
@@ -1,4 +1,4 @@
-import { collection, getDocs, doc, getDoc, addDoc } from 'firebase/firestore'
+import { collection, getDocs, doc, getDoc, addDoc, setDoc } from 'firebase/firestore'
 import { db } from './firebase'
 import { Account, Transaction, Goal } from './types'
 import Papa from 'papaparse'
@@ -40,7 +40,9 @@ export async function importCsv(uid: string, file: File) {
   for (const row of parsed.data as any[]) {
     if (!row.collection) continue
     const { collection: col, id, ...rest } = row as any
-    await addDoc(collection(db, 'users', uid, col), rest)
+    const colRef = collection(db, 'users', uid, col)
+    if (id) await setDoc(doc(colRef, id), rest)
+    else await addDoc(colRef, rest)
   }
 }
 


### PR DESCRIPTION
## Summary
- keep document IDs when importing CSV backups

## Testing
- `npx tsc --noEmit` *(fails: cannot find React type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_687ad3841800832aa85bf9c4d6f19208