### PR TITLE
Add R&D page and document API placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,10 @@ VITE_FIREBASE_PROJECT_ID=
 VITE_FIREBASE_STORAGE_BUCKET=
 VITE_FIREBASE_MESSAGING_SENDER_ID=
 VITE_FIREBASE_APP_ID=
+
+# Service account JSON for server-side scripts (required when enabling
+# Google Drive backups or Instant Payments APIs)
+FIREBASE_SERVICE_ACCOUNT=
+
+# Endpoint for Mercado Pago yield rates (requires external API access)
+MP_YIELD_ENDPOINT=

--- a/scripts/applyMpYield.js
+++ b/scripts/applyMpYield.js
@@ -1,6 +1,9 @@
 import { initializeApp, cert } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 
+// This script calculates daily yield using data from Mercado Pago. The API
+// endpoints are placeholders until official support is available.
+
 const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT;
 if (!serviceAccount) {
   console.error('Missing FIREBASE_SERVICE_ACCOUNT env var');
@@ -64,3 +67,4 @@ main().catch((err) => {
   console.error(err);
   process.exit(1);
 });
+

--- a/scripts/fetchMpYield.js
+++ b/scripts/fetchMpYield.js
@@ -1,6 +1,9 @@
 import { initializeApp, cert } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 
+// This script requires an external API endpoint that isn't available yet.
+// Leave the configuration in place so it can be enabled once access is granted.
+
 const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT;
 if (!serviceAccount) {
   console.error('Missing FIREBASE_SERVICE_ACCOUNT env var');
@@ -26,3 +29,4 @@ main().catch((err) => {
   console.error(err);
   process.exit(1);
 });
+

--- a/scripts/fetchUsdArs.js
+++ b/scripts/fetchUsdArs.js
@@ -1,6 +1,9 @@
 import { initializeApp, cert } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 
+// Fetching official USD rates requires external connectivity which may be
+// restricted. Keep this script for future API access.
+
 const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT;
 if (!serviceAccount) {
   console.error('Missing FIREBASE_SERVICE_ACCOUNT env var');
@@ -24,3 +27,4 @@ main().catch((err) => {
   console.error(err);
   process.exit(1);
 });
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Layout } from './components/Layout'
 import Login from './pages/Login'
 import Dashboard from './pages/Dashboard'
 import Settings from './pages/Settings'
+import Research from './pages/Research'
 
 export default function App() {
   return (
@@ -22,6 +23,7 @@ export default function App() {
           >
             <Route path="dashboard" element={<Dashboard />} />
             <Route path="settings" element={<Settings />} />
+            <Route path="research" element={<Research />} />
             <Route index element={<Dashboard />} />
           </Route>
         </Routes>

--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -28,6 +28,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   }, [])
 
   const login = async () => {
+    // TODO: configure this provider with your Google account when
+    // Instant Payments integration becomes available. This placeholder
+    // uses the default Firebase Google provider.
     const provider = new GoogleAuthProvider()
     await signInWithPopup(auth, provider)
   }

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -46,6 +46,9 @@ export async function importCsv(uid: string, file: File) {
   }
 }
 
+// TODO: once the Google Drive API can be used with your Instant
+// Payments account, supply the OAuth token in `driveToken` and enable
+// this upload. Until then it will silently skip if no token exists.
 export async function uploadBackup(uid: string, data: BackupData) {
   const tokenDoc = await getDoc(doc(db, 'users', uid, 'driveToken'))
   if (!tokenDoc.exists()) return
@@ -73,5 +76,7 @@ export async function uploadBackup(uid: string, data: BackupData) {
 
 export async function triggerBackup(uid: string) {
   const data = await fetchBackupData(uid)
+  // Upload is optional until Google APIs are configured
   await uploadBackup(uid, data)
 }
+

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -9,6 +9,7 @@ export const Layout = () => {
         <nav className="space-y-2">
           <Link to="/dashboard" className="block">Dashboard</Link>
           <Link to="/settings" className="block">Settings</Link>
+          <Link to="/research" className="block">I+D</Link>
         </nav>
       </aside>
       <div className="flex-1 flex flex-col">

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -2,6 +2,8 @@ import { initializeApp } from 'firebase/app'
 import { getAuth } from 'firebase/auth'
 import { getFirestore, enableIndexedDbPersistence } from 'firebase/firestore'
 
+// Fill these values with the Firebase project linked to your Google account
+// that will handle Instant Payments once the APIs are available.
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
   authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,

--- a/src/pages/Research.tsx
+++ b/src/pages/Research.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+
+export default function Research() {
+  const [showInfo, setShowInfo] = useState(false)
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Investigación y Desarrollo</h1>
+      <button onClick={() => setShowInfo(!showInfo)} className="border px-2 py-1">
+        {showInfo ? 'Ocultar info' : 'Ver información'}
+      </button>
+      {showInfo && (
+        <div className="mt-4 space-y-2">
+          <div>
+            <h2 className="font-semibold">Funciones disponibles</h2>
+            <ul className="list-disc ml-5">
+              <li>Inicio de sesión con Google</li>
+              <li>Gestión de cuentas y transacciones</li>
+              <li>Exportación e importación de datos</li>
+            </ul>
+          </div>
+          <div className="mt-4">
+            <h2 className="font-semibold">Próximas funciones</h2>
+            <ul className="list-disc ml-5">
+              <li>Integración con pagos instantáneos</li>
+              <li>Sincronización con cuentas externas (Binance, Mercado Pago)</li>
+              <li>Notificaciones y experiencia PWA</li>
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add new Research page with info toggle
- link Research page in layout and router
- document how to configure Google account for Instant Payments
- note unimplemented API spots in backup and script files

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d59d06b40832a8544982a42f3d08c