### PR TITLE
Fix gh-pages deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,10 @@ jobs:
       # file yet. This generates one automatically for future runs.
       - run: npm install
       - run: npm run build
+      - name: Set up Git user
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
       - run: npx gh-pages -d dist
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- fix gh-pages workflow by configuring git user before pushing

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d5fd1c930832ab632a1a2bfb3b93a