### PR TITLE
Add Mercado Pago sync function

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ FIREBASE_SERVICE_ACCOUNT=
 
 # Endpoint for Mercado Pago yield rates (requires external API access)
 MP_YIELD_ENDPOINT=
+
+# Access token for Mercado Pago APIs
+MP_ACCESS_TOKEN=

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This project uses React, Vite and Tailwind.
    - `VITE_FIREBASE_APP_ID` – the web app ID.
    - `FIREBASE_SERVICE_ACCOUNT` – JSON credentials for a service account used by server-side scripts (required for Google Drive backups or Instant Payments).
    - `MP_YIELD_ENDPOINT` – Mercado Pago yield rates endpoint if you have external API access.
+   - `MP_ACCESS_TOKEN` – private access token for Mercado Pago APIs used in Cloud Functions.
 2. Install dependencies with `npm install`. This command will also create a `package-lock.json` file used by the build workflow.
 3. Run `npm run dev` to start the development server.
 

--- a/functions/src/mpMovements.ts
+++ b/functions/src/mpMovements.ts
@@ -1,0 +1,40 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import mercadopago from "mercadopago";
+
+admin.initializeApp();
+mercadopago.configure({ access_token: process.env.MP_ACCESS_TOKEN! });
+
+export const syncMpMovements = functions.pubsub
+  .schedule("every 24 hours")
+  .timeZone("America/Argentina/Cordoba")
+  .onRun(async () => {
+    const { body } = await mercadopago.payment.search({
+      qs: { offset: 0, limit: 1000 },
+    });
+
+    const batch = admin.firestore().batch();
+    body.results.forEach((p: any) => {
+      const ref = admin.firestore().doc(`mpMovements/${p.id}`);
+      batch.set(
+        ref,
+        {
+          status: p.status,
+          description: p.description,
+          amount: p.transaction_amount,
+          fee: p.fee_details?.[0]?.amount || 0,
+          net: p.net_received_amount,
+          date: p.date_created,
+        },
+        { merge: true }
+      );
+    });
+    await batch.commit();
+  });
+
+export const mpBalance = functions.https.onCall(async () => {
+  const { data } = await mercadopago.get("/v1/account/balance", {
+    access_token: process.env.MP_ACCESS_TOKEN,
+  });
+  return data;
+});

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "firebase": "^9.23.0",
     "react-router-dom": "^6.14.1",
     "firebase-admin": "^11.10.1",
-    "papaparse": "^5.4.1"
+    "papaparse": "^5.4.1",
+    "mercadopago": "^1.6.6"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",


### PR DESCRIPTION
## Summary
- document `MP_ACCESS_TOKEN` env var
- add Mercado Pago SDK dependency
- store `MP_ACCESS_TOKEN` in example env file
- provide Firebase Functions script to sync MercadoPago payments

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687dae6d7168832a873ccf7ef8011464