### PR TITLE
Mejoras de UI y modo oscuro

### DIFF
--- a/src/pages/FinTrackerPage.tsx
+++ b/src/pages/FinTrackerPage.tsx
@@ -92,6 +92,10 @@ const FinTrackerPage: FC = () => {
     setFixedExpenses(prev => prev.filter(fx => fx.id !== id))
   }
 
+  const handleUpdateFixed = (id: string, data: Partial<FixedExpense>) => {
+    setFixedExpenses(prev => prev.map(fx => fx.id === id ? { ...fx, ...data } : fx))
+  }
+
   const handleExport = () => {
     const data = JSON.stringify({ accounts, transactions, goals, categories, fixedExpenses }, null, 2)
     const blob = new Blob([data], { type: 'application/json' })
@@ -163,7 +167,7 @@ const FinTrackerPage: FC = () => {
       case 'categories':
         return <CategoriesView categories={categories} onAdd={handleAddCategory} onDelete={handleDeleteCategory} />
       case 'fixed':
-        return <FixedExpensesView expenses={fixedExpenses} onAdd={handleAddFixed} onDelete={handleDeleteFixed} />
+        return <FixedExpensesView expenses={fixedExpenses} onAdd={handleAddFixed} onDelete={handleDeleteFixed} onUpdate={handleUpdateFixed} />
       case 'goals':
         return <Card><h2 className="text-2xl font-bold text-slate-800">Goals</h2><p className="text-slate-500 mt-4">Goal management coming soon!</p></Card>
       case 'settings':

--- a/src/views/CategoriesView.tsx
+++ b/src/views/CategoriesView.tsx
@@ -20,27 +20,22 @@ const CategoriesView: FC<Props> = ({ categories, onAdd, onDelete }) => {
   }
 
   return (
-    <div className="grid gap-6 md:grid-cols-2">
-      <Card>
-        <h2 className="text-2xl font-bold text-slate-800 mb-6">Categories</h2>
-        <form onSubmit={submit} className="flex gap-2">
-          <input value={name} onChange={e => setName(e.target.value)} className="flex-grow p-2 border border-slate-300 rounded-md" placeholder="Category name" required />
-          <Button>Add</Button>
-        </form>
-      </Card>
-      <Card>
-        <h3 className="font-bold text-lg mb-4 text-slate-800">Existing Categories</h3>
-        <ul className="divide-y divide-slate-200">
-          {categories.map(cat => (
-            <li key={cat.id} className="flex items-center justify-between py-2">
-              <span>{cat.name}</span>
-              <Button variant="danger" onClick={() => onDelete(cat.id)}>Delete</Button>
-            </li>
-          ))}
-          {categories.length === 0 && <p className="text-slate-500 text-center">No categories yet.</p>}
-        </ul>
-      </Card>
-    </div>
+    <Card>
+      <h2 className="text-2xl font-bold text-slate-800 mb-6">Categories</h2>
+      <form onSubmit={submit} className="flex gap-2 mb-4">
+        <input value={name} onChange={e => setName(e.target.value)} className="flex-grow p-2 border border-slate-300 rounded-md" placeholder="Category name" required />
+        <Button>Add</Button>
+      </form>
+      <ul className="divide-y divide-slate-200">
+        {categories.map(cat => (
+          <li key={cat.id} className="flex items-center justify-between py-2">
+            <span>{cat.name}</span>
+            <Button variant="danger" onClick={() => onDelete(cat.id)}>Delete</Button>
+          </li>
+        ))}
+        {categories.length === 0 && <p className="text-slate-500 text-center">No categories yet.</p>}
+      </ul>
+    </Card>
   )
 }
 

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-  darkMode: 'media',
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
     extend: {},


### PR DESCRIPTION
## Resumen
- cambio de `darkMode` a `class` para que el interruptor funcione correctamente
- posibilidad de editar gastos fijos y sin paréntesis en la fecha
- formulario de categorías integrado sobre la lista existente
- el gráfico principal se muestra en un modal grande al expandirlo

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ea1e03248832a9a9d43df19399116