### PR TITLE
Add CI/CD pipeline with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test -- --run
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: dist
+

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ Ahora incluye soporte para múltiples idiomas (inglés y español) y mejoras de 
 
 - Todos los datos se guardan localmente en tu navegador.
 - Puedes presionar **N** en cualquier momento para añadir una transacción.
+
+## Integración continua y despliegue
+
+Este repositorio utiliza [GitHub Actions](https://github.com/features/actions) para ejecutar las pruebas, construir el proyecto y desplegar automáticamente la aplicación en GitHub Pages cuando se hace push a la rama `main`.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint, test, build, and deploy on pushes to `main`
- document automated CI/CD in README

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6895477e2e688331b0ab433f96672a2e